### PR TITLE
Add alerts worker

### DIFF
--- a/alerts/apps.py
+++ b/alerts/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class AlertsConfig(AppConfig):
+    name = 'alerts'

--- a/alerts/apps.py
+++ b/alerts/apps.py
@@ -19,7 +19,6 @@ class AlertsConfig(AppConfig):
         # It's probably fine and will not happen in production.
         # See:
         # https://stackoverflow.com/questions/33814615/how-to-avoid-appconfig-ready-method-running-twice-in-django
-
         if settings.ACTIVE:
             worker = AlertWorker()
             worker.start()

--- a/alerts/apps.py
+++ b/alerts/apps.py
@@ -3,3 +3,21 @@ from django.apps import AppConfig
 
 class AlertsConfig(AppConfig):
     name = 'alerts'
+
+    def ready(self):
+        # NOTE: cannot be imported at module-level,
+        # because importing this will trigger import of models that are
+        # only ready when all apps have been loaded.
+        # Example error:
+        # "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet."
+        from alerts.worker import AlertWorker
+
+        # NOTE: in development, Django runs two processes:
+        # - One for the development server
+        # - One for the auto-reload mechanism
+        # Which results in this method being called twice.
+        # It's probably fine and will not happen in production.
+        # See:
+        # https://stackoverflow.com/questions/33814615/how-to-avoid-appconfig-ready-method-running-twice-in-django
+        worker = AlertWorker()
+        worker.start()

--- a/alerts/apps.py
+++ b/alerts/apps.py
@@ -5,12 +5,12 @@ class AlertsConfig(AppConfig):
     name = 'alerts'
 
     def ready(self):
-        # NOTE: cannot be imported at module-level,
-        # because importing this will trigger import of models that are
-        # only ready when all apps have been loaded.
-        # Example error:
+        # NOTE: should not be imported at module-level,
+        # because it would trigger an import of models that are
+        # only ready when all apps have been loaded and raise the following:
         # "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet."
         from alerts.worker import AlertWorker
+        from . import settings
 
         # NOTE: in development, Django runs two processes:
         # - One for the development server
@@ -19,5 +19,7 @@ class AlertsConfig(AppConfig):
         # It's probably fine and will not happen in production.
         # See:
         # https://stackoverflow.com/questions/33814615/how-to-avoid-appconfig-ready-method-running-twice-in-django
-        worker = AlertWorker()
-        worker.start()
+
+        if settings.ACTIVE:
+            worker = AlertWorker()
+            worker.start()

--- a/alerts/jobs.py
+++ b/alerts/jobs.py
@@ -1,0 +1,61 @@
+import logging
+import threading
+
+from series.models import APIShow
+from tmdb.client import tmdb_client
+
+
+class AiringShowsJob(threading.Thread):
+    """Job to fetch shows airing today and notify users that follow them.
+
+    Usage
+    -----
+    Intended to be used as a regular thread:
+    >>> job = AiringShowsJob()
+    >>> job.start()
+    >>> job.join()
+
+    Logs
+    ----
+    Debug logs are available on the `alerts` logger (see `LOGGING` in
+    settings.py).
+    """
+
+    _logger = logging.getLogger('alerts')
+
+    def notify_followers(self, show: APIShow):
+        for user in show.followers.all():
+            # TODO send an email
+            self._logger.debug({
+                'event': 'alert_sent',
+                'user': user.pk,
+                'show': show.pk,
+            })
+
+    def run(self):
+        self._logger.info({
+            'event': 'started',
+        })
+
+        all_airing_today_ids = tmdb_client.get_airing_today_ids()
+        saved_airing_today = APIShow.objects.filter(id__in=all_airing_today_ids)
+
+        self._logger.debug({
+            'all': all_airing_today_ids,
+            'in_database': list(saved_airing_today.values_list(
+                'id', flat=True
+            )),
+            'count': len(saved_airing_today),
+        })
+
+        if saved_airing_today:
+            self._logger.info({
+                'event': 'start_sending_alerts',
+            })
+
+        for show in saved_airing_today:
+            self.notify_followers(show)
+
+        self._logger.info({
+            'event': 'done',
+        })

--- a/alerts/settings.py
+++ b/alerts/settings.py
@@ -1,0 +1,5 @@
+"""Alerts app settings."""
+from django.conf import settings
+
+# Control whether the worker should start
+ACTIVE = getattr(settings, 'ALERTS_ACTIVE', False)

--- a/alerts/worker.py
+++ b/alerts/worker.py
@@ -20,9 +20,6 @@ class AlertWorker(threading.Thread):
     period_seconds = ONE_DAY
     _logger = logging.getLogger('alerts')
 
-    def __init__(self):
-        super().__init__()
-
     @staticmethod
     def main_thread_is_alive() -> bool:
         """Check if the main thread is still running.

--- a/alerts/worker.py
+++ b/alerts/worker.py
@@ -1,0 +1,54 @@
+"""Long-running worker that executes alerting jobs."""
+import logging
+import threading
+
+from alerts.jobs import AiringShowsJob
+
+ONE_DAY = 60 * 60 * 24
+
+
+class AlertWorker(threading.Thread):
+    """Check for airing jobs every day.
+
+    Notes
+    -----
+    Controlling the update time of day is not yet supported.
+    The alerting job will be executed every day at the time
+    that this thread is started.
+    """
+
+    period_seconds = ONE_DAY
+    _logger = logging.getLogger('alerts')
+
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def main_thread_is_alive() -> bool:
+        """Check if the main thread is still running.
+
+        This check is required because the web server may not be able
+        to correctly stop this thread and the Timer it has fired.
+        """
+        for thread in threading.enumerate():
+            if thread.getName().find('MainThread') != -1:
+                return thread.is_alive()
+        return False
+
+    def schedule_next(self):
+        """Schedule another run of this job after the configured period."""
+        return threading.Timer(self.period_seconds, lambda: self.run())
+
+    def run(self):
+        if not self.main_thread_is_alive():
+            self._logger.info('Skipping because main thread has exited.')
+            return
+
+        job = AiringShowsJob()
+        timer = self.schedule_next()
+
+        job.start()
+        timer.start()
+
+        job.join()
+        timer.join()

--- a/tmdb/client.py
+++ b/tmdb/client.py
@@ -12,6 +12,7 @@ from typing import List
 
 import requests
 
+from django.conf import settings
 from tmdb.pagination import collect_paginated_results
 from .parsers.shows import ShowParser
 from .datatypes import Show
@@ -109,7 +110,10 @@ class TMDBClient:
         """
         return collect_paginated_results(
             fetch_page=lambda page: self._request('tv/airing_today', {
-                'page': page
+                'page': page,
+                # Results differ by timezone, use the one configured
+                # on this server.
+                'timezone': settings.TIME_ZONE,
             }),
             total_pages=lambda data: data['total_pages'],
             extract=lambda data: [show['id'] for show in data['results']],

--- a/tmdb/pagination.py
+++ b/tmdb/pagination.py
@@ -1,0 +1,42 @@
+"""Generic TMDB API pagination utilities."""
+from typing import TypeVar, List, Callable
+
+from requests import Response
+
+T = TypeVar('T')
+
+
+def collect_paginated_results(
+        fetch_page: Callable[[int], Response],
+        total_pages: Callable[[dict], int],
+        extract: Callable[[dict], List[T]]) -> List[T]:
+    """Collect all pages of a paginated resource.
+
+    Collection workflow:
+    1. Fetch the first page.
+    2. Identify the total number of pages from this response.
+    3. Fetch the remaining pages, if any.
+
+    :param fetch_page
+        A function that takes one argument (the page number) and
+        returns a requests.Response object.
+    :param total_pages
+        A function that takes one argument (the raw JSON data from
+        the response) and returns the total number of pages.
+    :param extract
+        A function that takes one argument (the raw JSON data from
+        the response) and returns a list of items of interest.
+        For example, this may return the list of full objects in
+        a "results" field, or a list of a specific field for each object.
+    """
+    results: List[T] = []
+
+    response = fetch_page(1)
+    data = response.json()
+    results.extend(extract(data))
+
+    for page in range(2, total_pages(data) + 1):
+        response = fetch_page(page)
+        results.extend(extract(response.json()))
+
+    return results

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -104,6 +104,33 @@ AUTH_USER_MODEL = 'users.User'
 LOGIN_URL = 'accounts/login/'
 LOGIN_REDIRECT_URL = '/'
 
+# Logging
+# https://docs.djangoproject.com/fr/2.1/topics/logging/#examples
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname} {asctime} {module} {thread:d} {message}',
+            'style': '{',
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        'alerts': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -106,6 +106,10 @@ AUTH_USER_MODEL = 'users.User'
 LOGIN_URL = 'accounts/login/'
 LOGIN_REDIRECT_URL = '/'
 
+# Alerts config
+# NOTE: a non-empty value for the env variable is considered as True
+ALERTS_ACTIVE = os.getenv('ALERTS_ACTIVE', False)
+
 # Logging
 # https://docs.djangoproject.com/fr/2.1/topics/logging/#examples
 LOGGING = {

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -142,7 +142,7 @@ LOGGING = {
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Paris'
 
 USE_I18N = True
 

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -31,8 +31,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'series.apps.SeriesConfig',
     'users.apps.UsersConfig',
+    'series.apps.SeriesConfig',
+    'tmdb.apps.TmdbConfig',
+    'alerts.apps.AlertsConfig',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
# Description

- Create `AiringShowsJob`, a thread that checks jobs airing today and notifies users that follow them.
- As a side effect, create a generic pagination utility to fetch all items in a paginated TMDB API result.
- Create `AlertsWorker` that runs this job every day.

The worker is started (and makes its first update) upon server startup **only if the `ALERTS_ACTIVE` environment variable is set**.

# Next steps

- Send an email when notifying users (hint: SendGrid?).
- (Optional) Allow to define the time when the worker runs the job.
