### PR TITLE
Specify TMDB_API_KEY in settings.py

### DIFF
--- a/tmdb/client.py
+++ b/tmdb/client.py
@@ -6,7 +6,6 @@ For looser coupling, external packages should probably use the
 shortcut functions defined in shortcuts.py.
 """
 
-import os
 import warnings
 from typing import List
 
@@ -14,6 +13,7 @@ import requests
 
 from .parsers.shows import ShowParser
 from .datatypes import Show
+from . import settings
 
 
 class TMDBClient:
@@ -103,19 +103,18 @@ def get_tmdb_client(api_key: str = None) -> TMDBClient:
 
     :param api_key: str, optional
         If not given, the API key is retrieved from the TMDB_API_KEY
-        environment variable.
-        If the environment variable is not set, raises a warning.
+        setting as defined in `settings.py`.
     :return client: TMDBClient
     :raises UserWarning:
-        If the TMDB_API_KEY environment variable is not set,
+        If the TMDB_API_KEY setting is not set,
         but it was used to build the client.
     """
     if api_key is None:
-        api_key = os.getenv('TMDB_API_KEY')
+        api_key = settings.API_KEY
         if api_key is None:
             message = (
-                'TMDB_API_KEY environment variable not set! Requests to '
-                'the TMDB API will most likely fail.'
+                'TMDB_API_KEY setting not set! '
+                'Requests to the TMDB API will most likely fail.'
             )
             warnings.warn(message)
     return TMDBClient(api_key=api_key)

--- a/tmdb/settings.py
+++ b/tmdb/settings.py
@@ -1,0 +1,6 @@
+"""TMDB client settings."""
+
+from django.conf import settings
+
+
+API_KEY = getattr(settings, 'TMDB_API_KEY', None)

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'series.apps.SeriesConfig',
     'users.apps.UsersConfig',
+    'tmdb.apps.TmdbConfig',
 ]
 
 MIDDLEWARE = [
@@ -124,3 +125,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+
+# TMDB configuration
+TMDB_API_KEY = os.environ.get('TMDB_API_KEY')


### PR DESCRIPTION
# Description

- Instead of implicitly retrieving the `TMDB_API_KEY` from an environment variable in `client.py`, let us specify it in `settings.py`.
