### PR TITLE
Add SendGrid email configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ $ python manage.py runserver
 The following settings are available and can be defined in a git-ignored `.env` file located at the root of your project directory:
 
 - `TMDB_API_KEY`: will be used to retrieve and search TV shows on the TheMovieDatabase (TMDB) API. Acquiring an API key requires to create a (free) TMDB account. Please refer to the API's [Getting Started guide](https://developers.themoviedb.org/3/getting-started/introduction) for how to create an API key.
+- `SENDGRID_API_KEY`: used to send alerts via email using SendGrid (see [next section](#Configuring-email-delivery-of-alerts)).
 
 ### Configuring email delivery of alerts
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Start development server:
 $ python manage.py runserver
 ```
 
+### Configuring email delivery of alerts
+
+Alerts about new episodes are delivered via email.
+
+In production, email delivery is powered by [SendGrid](https://sendgrid.com). Credentials are associated to the `uptv` Heroku application and not disclosed here, obviously.
+
+It is also possible to use SendGrid in development. You will need to acquire a valid SendGrid API key (free hobby accounts are available) and to provide it through the `SENDGRID_API_KEY` environment variable.
+
+> Note that in `DEBUG` mode, emails will purposefully NOT be sent unless the `SENDGRID_SANDBOX_MODE_IN_DEBUG` is set to `False`. For more information, see [django-sendgrid-v5](https://github.com/sklarsa/django-sendgrid-v5).
+
+If SendGrid email is not configured, emails will not be sent but alerts will still be logged to the console.
+
 ## Contributing
 
 - Create a branch, e.g. `feature/awesome-feature` or `fix/very-nasty-bug`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 gunicorn
 python-dotenv
 Pillow  # required to use ImageField
+django-sendgrid-v5

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -111,7 +111,6 @@ LOGIN_REDIRECT_URL = '/'
 # https://docs.djangoproject.com/fr/2.1/topics/email/
 EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
 SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
-SENDGRID_SANDBOX_MODE_IN_DEBUG = False
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -95,14 +95,23 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# Use custom user class
+# User model
 # See:
 # https://docs.djangoproject.com/en/2.1/topics/auth/customizing/#substituting-a-custom-user-model
 AUTH_USER_MODEL = 'users.User'
 
+# Login page configuration
 # See: https://docs.djangoproject.com/fr/2.1/ref/settings/#login-url
 LOGIN_URL = 'accounts/login/'
 LOGIN_REDIRECT_URL = '/'
+
+
+# Email
+# For how to send emails in Django, see:
+# https://docs.djangoproject.com/fr/2.1/topics/email/
+EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
+SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
+SENDGRID_SANDBOX_MODE_IN_DEBUG = False
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/


### PR DESCRIPTION
# Description

Heroku provides a (free) SendGrid add-on to send email.

- Add configuration for the SendGrid email backend
- Document new settings in `README.md`