### PR TITLE
Serve static files in production using WhiteNoise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 gunicorn
 python-dotenv
 Pillow  # required to use ImageField
+whitenoise  # service of static files in production

--- a/uptv/settings.py
+++ b/uptv/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
# Description

Static files were not served in production (e.g. the browser could not fetch the CSS files, because the server did not actually serve them). In development it was fine because Django's development server (when running `python manage.py runserver`) did serve static files.

- Use [WhiteNoise](http://whitenoise.evans.io/en/stable/) to efficiently serve static files in production.