### PR TITLE
Retrieve and display episode synopsis

### DIFF
--- a/series/templates/series/show_details.html
+++ b/series/templates/series/show_details.html
@@ -64,3 +64,11 @@
 
     </div>
 </div>
+{% for season in show.list_seasons reversed %}
+    <p>Season {{ season.number }}</p>
+<ul>
+    {% for episode in season.list_episodes reversed %}
+    <li> Episode {{ episode.number }}: {{ episode.synopsis }} </li>
+    {% endfor %}
+</ul>
+{% endfor %}

--- a/tmdb/client.py
+++ b/tmdb/client.py
@@ -92,8 +92,15 @@ class TMDBClient:
         :param show_id: id of the show in the API.
         :return: a Show object
         """
-        resp = self._request(f'tv/{show_id}')
-        data: dict = resp.json()
+        show_resp = self._request(f'tv/{show_id}')
+        data: dict = show_resp.json()
+        season_count: int = data['number_of_seasons']
+        seasons: List[dict] = []
+        for season_number in range(1, season_count + 1):
+            season_resp = self._request(f'tv/{show_id}/season/{season_number}')
+            season_data: dict = season_resp.json()
+            seasons.append(season_data)
+        data['list_seasons'] = seasons
         parser = self._get_show_parser()
         return parser.for_detail(data)
 

--- a/tmdb/datatypes.py
+++ b/tmdb/datatypes.py
@@ -6,6 +6,20 @@ from typing import List
 
 
 @dataclass
+class Episode:
+    """Represents the details of an episode."""
+    number: int
+    synopsis: str
+
+
+@dataclass
+class Season:
+    """Represents a season of a show"""
+    number: int
+    list_episodes: List[Episode]
+
+
+@dataclass
 class Show:
     """Represents the details about a TV show."""
     id: int
@@ -18,3 +32,9 @@ class Show:
     genres: List[str] = None
     next_episode_date: datetime = None
     last_episode_date: datetime = None
+    list_seasons: List[Season] = None
+
+
+
+
+

--- a/tmdb/parsers/seasons.py
+++ b/tmdb/parsers/seasons.py
@@ -1,0 +1,32 @@
+"""Parsers of season objects."""
+
+from typing import List
+
+from ..datatypes import Season, Episode
+from .base import Parser
+
+
+class SeasonParser(Parser[Season]):
+
+    object_class = Season
+
+    @staticmethod
+    def _parse_episode(episode: dict) -> Episode:
+        number: int = episode['episode_number']
+        synopsis: str = episode['overview']
+        return Episode(number=number, synopsis=synopsis)
+
+    def _get_list_episodes(self, data: dict) -> List[Episode]:
+        episodes: List[dict] = data['episodes']
+        list_episodes = []
+        for episode in episodes:
+            list_episodes.append(self._parse_episode(episode))
+        # To be sure that the episodes are sorted in the right order
+        list_episodes.sort(key=lambda el: el.number)
+        return list_episodes
+
+    def get_kwargs(self, data: dict) -> dict:
+        return {
+            'number': data['season_number'],
+            'list_episodes': self._get_list_episodes(data)
+        }

--- a/tmdb/parsers/shows.py
+++ b/tmdb/parsers/shows.py
@@ -1,9 +1,10 @@
 """Parsers of show objects."""
 
 from datetime import datetime
-from typing import Union
+from typing import Union, List
 
-from ..datatypes import Show
+from tmdb.parsers.seasons import SeasonParser
+from ..datatypes import Show, Season, Episode
 from .base import Parser, ParserGroup
 
 
@@ -70,6 +71,17 @@ class ShowDetailParser(ShowListParser):
         next_episode: dict = data['next_episode_to_air'] or {}
         return self._parse_date(next_episode.get('air_date'))
 
+    def _get_list_seasons(self, data: dict) -> List[Season]:
+        seasons = data['list_seasons']
+        list_seasons = []
+        for season_number in range(len(seasons)):
+            season_parser = SeasonParser()
+            season = season_parser.parse(seasons[season_number])
+            list_seasons.append(season)
+        # To be sure that the seasons are sorted in the right order
+        list_seasons.sort(key=lambda el: el.number)
+        return list_seasons
+
     def get_kwargs(self, data: dict) -> dict:
         return {
             **super().get_kwargs(data),
@@ -80,6 +92,7 @@ class ShowDetailParser(ShowListParser):
             'creation_date': self._parse_date(data['first_air_date']),
             'last_episode_date': self._parse_date(data['last_air_date']),
             'next_episode_date': self._get_next_episode_date(data),
+            'list_seasons': self._get_list_seasons(data)
         }
 
 


### PR DESCRIPTION
API call to retrieve and display episode synopsis and seasons.

NOTE : the display of a show page is now way longer due to added API call, especially for shows with lots of episodes (a few seconds for "Friends"). See if we can make the Api call later if needed.