### PR TITLE
Add tests for search page

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import socket
+
+
+def nope(*args, **kwargs):
+    raise Exception('A test tried to access the internet!')
+
+
+socket.socket = nope

--- a/tests/test_series/test_search.py
+++ b/tests/test_series/test_search.py
@@ -1,0 +1,10 @@
+from django.test import TestCase, override_settings
+
+
+@override_settings(TMDB_CLIENT='tmdb.mock.MockTMDBClient')
+class SearchShowsTest(TestCase):
+    """Test searching for shows."""
+
+    def test_search_shows(self):
+        response = self.client.get('/search/walking')
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_series/test_search.py
+++ b/tests/test_series/test_search.py
@@ -5,6 +5,15 @@ from django.test import TestCase, override_settings
 class SearchShowsTest(TestCase):
     """Test searching for shows."""
 
-    def test_search_shows(self):
+    def test_can_access_search_page(self):
+        response = self.client.get('/search/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_perform_search_redirects_to_search_results_page(self):
+        response = self.client.post('/search/', {'search_term': 'walking'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/search/walking')
+
+    def test_access_search_results(self):
         response = self.client.get('/search/walking')
         self.assertEqual(response.status_code, 200)

--- a/tmdb/client.py
+++ b/tmdb/client.py
@@ -157,11 +157,20 @@ class TMDBClient:
 
 
 def get_tmdb_client() -> TMDBClient:
-    try:
+    """Return a instance of the currently configured TMDB client.
+
+    The TMDB client class is given by the `TMDB_CLIENT` setting.
+
+    :raises: ImportError
+        If the TMDB client class defined by `TMDB_CLIENT` could not
+        be imported.
+    """
+    if hasattr(django_settings, 'TMDB_CLIENT'):
         client_path = django_settings.TMDB_CLIENT
-    except AttributeError:
-        client_path = settings.TMDB_CLIENT
-    client_class: Type[TMDBClient] = import_string(client_path)
+        client_class = import_string(client_path)
+    else:
+        # Use the default
+        client_class = TMDBClient
     return client_class.build()
 
 

--- a/tmdb/client.py
+++ b/tmdb/client.py
@@ -7,7 +7,7 @@ shortcut functions defined in shortcuts.py.
 """
 
 import warnings
-from typing import List, Type
+from typing import List
 
 import requests
 from django.conf import settings as django_settings

--- a/tmdb/mock.py
+++ b/tmdb/mock.py
@@ -1,0 +1,71 @@
+"""TMDB mocks."""
+import json
+import os
+from contextlib import contextmanager
+from typing import List
+
+import requests
+
+from tmdb.client import TMDBClient
+from tmdb.datatypes import Show
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MOCK_DATA_PATH = os.path.join(_HERE, 'mock_data')
+
+
+class NoMockData(Exception):
+    """Raised when trying to make a mock request with having set mock data."""
+
+
+class MockResponse(requests.Response):
+
+    def __init__(self, data: dict):
+        super().__init__()
+        self._data = data
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self._data
+
+
+class MockTMDBClient(TMDBClient):
+    """Mock of the TMDB API client for usage in testing."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._data = None
+
+    def _make_request(self, url: str, params: dict):
+        """Make a mock HTTP request.
+
+        Must be used within a `with .data()` block.
+        """
+        if self._data is None:
+            raise NoMockData()
+        return MockResponse(self._data)
+
+    @contextmanager
+    def data(self, data: dict):
+        """Context manager to provide fake data for a request.
+
+        Usage
+        -----
+        >>> client = MockTMDBClient()
+        >>> with client.data({'id': 1, 'title': 'Walking Dead'}) as data:
+        >>>     response = client.search_show(data)
+        """
+        try:
+            self._data = data
+            yield data
+        finally:
+            self._data = None
+
+    def _load_from_disk(self, filename: str) -> dict:
+        path = os.path.join(_MOCK_DATA_PATH, filename)
+        with open(path, 'r') as f:
+            return json.loads(f.read())
+
+    def search_show(self, title: str) -> List[Show]:
+        mock = self._load_from_disk('search.json')
+        with self.data(mock):
+            return super().search_show(title)

--- a/tmdb/mock.py
+++ b/tmdb/mock.py
@@ -14,7 +14,7 @@ _MOCK_DATA_PATH = os.path.join(_HERE, 'mock_data')
 
 
 class NoMockData(Exception):
-    """Raised when trying to make a mock request with having set mock data."""
+    """Raised when trying to make a mock request without mock data."""
 
 
 class MockResponse(requests.Response):

--- a/tmdb/mock.py
+++ b/tmdb/mock.py
@@ -18,6 +18,7 @@ class NoMockData(Exception):
 
 
 class MockResponse(requests.Response):
+    """Mock of a GET 200 OK response with JSON data."""
 
     def __init__(self, data: dict):
         super().__init__()
@@ -43,6 +44,10 @@ class MockTMDBClient(TMDBClient):
         if self._data is None:
             raise NoMockData()
         return MockResponse(self._data)
+
+    def search_show(self, title: str) -> List[Show]:
+        with self.data('search.json'):
+            return super().search_show(title)
 
     @contextmanager
     def data(self, from_file: str = None, data: dict = None):
@@ -71,7 +76,3 @@ class MockTMDBClient(TMDBClient):
         path = os.path.join(_MOCK_DATA_PATH, filename)
         with open(path, 'r') as f:
             return json.loads(f.read())
-
-    def search_show(self, title: str) -> List[Show]:
-        with self.data('search.json'):
-            return super().search_show(title)

--- a/tmdb/mock.py
+++ b/tmdb/mock.py
@@ -36,7 +36,7 @@ class MockTMDBClient(TMDBClient):
         self._data = None
 
     def _make_request(self, url: str, params: dict):
-        """Make a mock HTTP request.
+        """Override the default implementation to make a mock HTTP request.
 
         Must be used within a `with .data()` block.
         """
@@ -45,15 +45,22 @@ class MockTMDBClient(TMDBClient):
         return MockResponse(self._data)
 
     @contextmanager
-    def data(self, data: dict):
-        """Context manager to provide fake data for a request.
+    def data(self, from_file: str = None, data: dict = None):
+        """Context manager to provide fake JSON data for a request.
+
+        :param from_file : str
+            Used to load data from a file, only if `data` is not passed.
+        :param data : dict
+            JSON data to be attached to the request.
 
         Usage
         -----
         >>> client = MockTMDBClient()
-        >>> with client.data({'id': 1, 'title': 'Walking Dead'}) as data:
+        >>> with client.data(from_file='search.json') as data:
         >>>     response = client.search_show(data)
         """
+        if data is None:
+            data = self._load_from_disk(from_file)
         try:
             self._data = data
             yield data
@@ -66,6 +73,5 @@ class MockTMDBClient(TMDBClient):
             return json.loads(f.read())
 
     def search_show(self, title: str) -> List[Show]:
-        mock = self._load_from_disk('search.json')
-        with self.data(mock):
+        with self.data('search.json'):
             return super().search_show(title)

--- a/tmdb/mock_data/search.json
+++ b/tmdb/mock_data/search.json
@@ -5,18 +5,18 @@
   "results": [
     {
       "original_name": "Brandon T. Jackson Show",
-      "id": 15145,
+      "id": 1,
       "name": "Brandon T. Jackson Show",
       "poster_path": null
     },
     {
-      "id": 36723,
+      "id": 2,
       "name": "Brandon Bets the World",
       "poster_path": null
 
     },
     {
-      "id": 16261,
+      "id": 3,
       "name": "Brandon's Herp Adventure",
       "poster_path": null
     }

--- a/tmdb/mock_data/search.json
+++ b/tmdb/mock_data/search.json
@@ -1,0 +1,24 @@
+{
+  "page": 1,
+  "total_results": 3,
+  "total_pages": 1,
+  "results": [
+    {
+      "original_name": "Brandon T. Jackson Show",
+      "id": 15145,
+      "name": "Brandon T. Jackson Show",
+      "poster_path": null
+    },
+    {
+      "id": 36723,
+      "name": "Brandon Bets the World",
+      "poster_path": null
+
+    },
+    {
+      "id": 16261,
+      "name": "Brandon's Herp Adventure",
+      "poster_path": null
+    }
+  ]
+}

--- a/tmdb/settings.py
+++ b/tmdb/settings.py
@@ -4,3 +4,4 @@ from django.conf import settings
 
 API_KEY = getattr(settings, 'TMDB_API_KEY', None)
 TIME_ZONE = getattr(settings, 'TIME_ZONE', None)
+TMDB_CLIENT = getattr(settings, 'TMDB_CLIENT', 'tmdb.client.TMDBClient')

--- a/tmdb/settings.py
+++ b/tmdb/settings.py
@@ -4,4 +4,3 @@ from django.conf import settings
 
 API_KEY = getattr(settings, 'TMDB_API_KEY', None)
 TIME_ZONE = getattr(settings, 'TIME_ZONE', None)
-TMDB_CLIENT = getattr(settings, 'TMDB_CLIENT', 'tmdb.client.TMDBClient')

--- a/tmdb/shortcuts.py
+++ b/tmdb/shortcuts.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from tmdb.client import tmdb_client
+from tmdb.client import get_tmdb_client
 from tmdb.datatypes import Show
 
 
@@ -12,7 +12,7 @@ def search_shows(title: str) -> List[Show]:
     :param title: str
     :return shows: list of Show
     """
-    return tmdb_client.search_show(title)
+    return get_tmdb_client().search_show(title)
 
 
 def retrieve_show(show_id: int) -> Show:
@@ -21,4 +21,4 @@ def retrieve_show(show_id: int) -> Show:
     :param show_id: ID of the show in the TMDB API.
     :return: Show
     """
-    return tmdb_client.retrieve_show(show_id)
+    return get_tmdb_client().retrieve_show(show_id)

--- a/tmdb/shortcuts.py
+++ b/tmdb/shortcuts.py
@@ -3,7 +3,6 @@
 from typing import List
 
 from tmdb.client import get_tmdb_client
-from tmdb.client import tmdb_client
 from tmdb.datatypes import Show, Season
 
 


### PR DESCRIPTION
# Description

Add tests for accessing the search page and performing a search.

This required mocking the TMDB API. As a result, I refactored the `TMDBClient` and the functions in `shortcuts.py` to allow the usage of a client defined by a `TMDB_CLIENT` setting. This setting is overridden during tests to use a `MockTMDBClient` instead, which does not perform any actual HTTP requests.

I monkey-patched the `socket` module in `tests/__init__.py` to alert if a test ever tries to access the internet (which might be dangerous/unwanted anyway).