### PR TITLE
Improve and add tests for subscribe/unsubscribe API endpoints

### DIFF
--- a/series/views.py
+++ b/series/views.py
@@ -1,4 +1,5 @@
 """Views for series app."""
+import json
 from typing import Union, Optional
 
 from django.urls import reverse
@@ -82,14 +83,29 @@ class FollowedSeriesView(LoginRequiredMixin, ListView):
         return APIShow.objects.filter(followers=self.request.user)
 
 
-class APISubscribe(View):
+class APILoginRequiredMixin(LoginRequiredMixin):
+
+    def handle_no_permission(self):
+        """Return a 401 Unauthorized error (JSON) if no credentials were passed.
+
+        The default behavior would have been to redirect to the login page
+        or return an HTML 403 response.
+        """
+        return HttpResponse(
+            status=401,
+            content_type='application/json',
+            content=json.dumps({'error': 'Credentials not provided.'})
+        )
+
+
+class APISubscribe(APILoginRequiredMixin, View):
     """View called when a user subscribes or unsubscribes to a new show."""
 
     def post(self, request, show_id: int):
-        """Called when a POST request is made to subscribe the user to the show
-        Adds the user to the followers list of the show
+        """Called when a POST request is made.
 
-        """
+        Subscribe the user to the show: add them to the show's list of
+        followers."""
         try:
             show = APIShow.objects.get(id=show_id)
         except APIShow.DoesNotExist:
@@ -98,13 +114,15 @@ class APISubscribe(View):
         return HttpResponse(200)
 
     def delete(self, request, show_id: int):
-        """Called when a DELETE request is made to unsubscribe the user from the show
-        Removes the user from the followers list of the show
+        """Called when a DELETE request is made.
 
-        """
+        Unsubscribe the user from the show: removes them from the show's
+        list of the followers."""
         show = APIShow.objects.filter(id=show_id).first()
-        show.followers.remove(request.user)
+        if show is not None:
+            show.followers.remove(request.user)
         return HttpResponse(200)
+
 
 class About(TemplateView):
     """View for the About page."""

--- a/tests/test_series/test_subscribe.py
+++ b/tests/test_series/test_subscribe.py
@@ -10,6 +10,7 @@ User = get_user_model()
 
 
 class SubscriptionTest:
+    """Base test holder for subscription test cases."""
 
     class TestCase(TestCase):
 
@@ -23,25 +24,35 @@ class SubscriptionTest:
         def _force_login(self):
             self.client.force_login(self.user)
 
+        def call(self, pk: int = 1402):
+            raise NotImplementedError
+
+        def call_logged_in(self, should_be_subscribed: bool):
+            self._force_login()
+            response = self.call()
+            self.assertEqual(response.status_code, 200)
+            show = APIShow.objects.get(pk=self.show.pk)
+            self.assertEqual(
+                should_be_subscribed,
+                show.followers.filter(pk=self.user.pk).exists(),
+            )
+
+        # This test is common to both test cases
+        def test_if_not_authenticated_then_unauthorized_with_json_error(self):
+            response = self.call()
+            self.assertEqual(response.status_code, 401)
+            data = json.loads(response.content)
+            self.assertIn('error', data)
+
 
 class TestSubscribe(SubscriptionTest.TestCase):
     """Test subscribing to a show."""
 
-    def _subscribe(self, pk=1402):
+    def call(self, pk=1402):
         return self.client.post(f'/subscribe/{pk}')
 
-    def test_if_not_authenticated_then_unauthorized_with_json_error(self):
-        response = self._subscribe()
-        self.assertEqual(response.status_code, 401)
-        data = json.loads(response.content)
-        self.assertIn('error', data)
-
     def test_if_not_subscribed_then_subscribed_after_call(self):
-        self._force_login()
-        response = self._subscribe()
-        self.assertEqual(response.status_code, 200)
-        show = APIShow.objects.get(pk=self.show.pk)
-        self.assertTrue(show.followers.filter(pk=self.user.pk).exists())
+        self.call_logged_in(should_be_subscribed=True)
 
     def test_if_show_does_not_exist_then_it_is_fetched_from_api(self):
         # TODO with a mock of the TMDB API
@@ -51,23 +62,13 @@ class TestSubscribe(SubscriptionTest.TestCase):
 class TestUnsubscribe(SubscriptionTest.TestCase):
     """Test unsubscribing to a show."""
 
-    def _unsubscribe(self, pk=1402):
+    def call(self, pk=1402):
         return self.client.delete(f'/subscribe/{pk}')
 
-    def test_if_not_authenticated_then_unauthorized_with_json_error(self):
-        response = self._unsubscribe()
-        self.assertEqual(response.status_code, 401)
-        data = json.loads(response.content)
-        self.assertIn('error', data)
-
     def test_if_subscribed_then_unsubscribed_after_call(self):
-        self._force_login()
-        response = self._unsubscribe()
-        self.assertEqual(response.status_code, 200)
-        show = APIShow.objects.get(pk=self.show.pk)
-        self.assertFalse(show.followers.filter(pk=self.user.pk).exists())
+        self.call_logged_in(should_be_subscribed=False)
 
     def test_if_show_does_not_exist_then_no_error(self):
         self._force_login()
-        response = self._unsubscribe(pk=42)
+        response = self.call(pk=42)
         self.assertEqual(response.status_code, 200)

--- a/tests/test_series/test_subscribe.py
+++ b/tests/test_series/test_subscribe.py
@@ -1,0 +1,73 @@
+"""Test API endpoints to subscribe to shows."""
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from series.models import APIShow
+
+User = get_user_model()
+
+
+class SubscriptionTest:
+
+    class TestCase(TestCase):
+
+        def setUp(self):
+            self.show = APIShow.objects.create(id=1402, title='Walking Dead')
+            self.user = User.objects.create_user(
+                username='johndoe',
+                password='admin',
+            )
+
+        def _force_login(self):
+            self.client.force_login(self.user)
+
+
+class TestSubscribe(SubscriptionTest.TestCase):
+    """Test subscribing to a show."""
+
+    def _subscribe(self, pk=1402):
+        return self.client.post(f'/subscribe/{pk}')
+
+    def test_if_not_authenticated_then_unauthorized_with_json_error(self):
+        response = self._subscribe()
+        self.assertEqual(response.status_code, 401)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+
+    def test_if_not_subscribed_then_subscribed_after_call(self):
+        self._force_login()
+        response = self._subscribe()
+        self.assertEqual(response.status_code, 200)
+        show = APIShow.objects.get(pk=self.show.pk)
+        self.assertTrue(show.followers.filter(pk=self.user.pk).exists())
+
+    def test_if_show_does_not_exist_then_it_is_fetched_from_api(self):
+        # TODO with a mock of the TMDB API
+        pass
+
+
+class TestUnsubscribe(SubscriptionTest.TestCase):
+    """Test unsubscribing to a show."""
+
+    def _unsubscribe(self, pk=1402):
+        return self.client.delete(f'/subscribe/{pk}')
+
+    def test_if_not_authenticated_then_unauthorized_with_json_error(self):
+        response = self._unsubscribe()
+        self.assertEqual(response.status_code, 401)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+
+    def test_if_subscribed_then_unsubscribed_after_call(self):
+        self._force_login()
+        response = self._unsubscribe()
+        self.assertEqual(response.status_code, 200)
+        show = APIShow.objects.get(pk=self.show.pk)
+        self.assertFalse(show.followers.filter(pk=self.user.pk).exists())
+
+    def test_if_show_does_not_exist_then_no_error(self):
+        self._force_login()
+        response = self._unsubscribe(pk=42)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# Description

- Add tests for the `POST /subscribe/:show_id` endpoint
- Add tests for the `DELETE /subscribe/:show_id` endpoint (and fix a bug when the show did not exist!)
- The endpoint now checks that the user is authenticated (I verified that it actually worked in the browser, thanks to CSRF cookie et al.)