### PR TITLE
Enhance email alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following settings are available and can be defined in your `.env` file:
 - `ALERTS_ACTIVE` (default: `False`): whether to start the alerts worker upon server startup.
 - `ALERTS_FORCE_EMAIL` (default: `False`): whether to force the alerts worker to deliver emails in development. If `False`, emails will not be delivered (useful for local testing). This setting has no effect in production mode.
 - `ALERTS_RUN_TIME` (default: `08:00:00`): `hh:mm:ss` string representing the run time of the alerts worker.
+- `ALERTS_MAIL_FROM` (default: `alerts@uptv.herokuapp.com`): the email address from which alerts will be sent.
 
 ## Contributing
 

--- a/alerts/settings.py
+++ b/alerts/settings.py
@@ -6,3 +6,4 @@ from django.utils.dateparse import parse_time
 # Control whether the worker should start
 ACTIVE = getattr(settings, 'ALERTS_ACTIVE', False)
 RUN_TIME = parse_time(getattr(settings, 'ALERTS_RUN_TIME', '08:00:00'))
+MAIL_FROM = getattr(settings, 'ALERTS_MAIL_FROM', 'alerts@uptv.herokuapp.com')

--- a/alerts/templates/alerts/alert.html
+++ b/alerts/templates/alerts/alert.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>New episodes</title>
+</head>
+<body>
+<p>
+    Hi {{ user.first_name }},
+</p>
+<p>
+    Hooray! New episodes of
+    <a href="https://uptv.herokuapp.com/tvshow/{{ show.id }}">{{ show.title }}</a>
+    are airing today. 📺🎉
+</p>
+<p>
+    Have a wonderful day,
+    <br>
+    The UpTV team
+</p>
+<hr>
+<p>
+    This email was sent to {{ user.email }} by <a href="https://uptv.herokuapp.com">UpTV</a>.
+</p>
+</body>
+</html>

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from django.core import mail
 from django.test import TestCase
+from django.utils.html import strip_tags
 from django.utils.timezone import now
 
 from alerts.worker import AlertsWorker
@@ -32,10 +33,11 @@ class EmailTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
         # Verify that the subject of the first message is correct.
-        self.assertEqual(mail.outbox[0].subject, notifier.get_subject())
+        self.assertEqual(mail.outbox[0].subject, notifier.get_subject(show))
 
         # Verify that the body of the first message is correct.
-        self.assertEqual(mail.outbox[0].body, notifier._get_full_content(show))  # Private but just for the test
+        expected_body = strip_tags(notifier.get_html_message(user, show))
+        self.assertEqual(mail.outbox[0].body, expected_body)
 
 
 class NextRunTest(TestCase):


### PR DESCRIPTION
# Description

- Use an HTML template for alerts, including a link to the show and to the UpTV home page
- Make the alerts email configurable (with a default)

![screenshot 2018-11-06 at 11 18 47](https://user-images.githubusercontent.com/15911462/48058445-b9a9a380-e1b6-11e8-9c96-ee1cf3bf05b2.png)
